### PR TITLE
feat: Add budget module role-action mappings for BUDGET-CREATOR and BUDGET_APPROVER

### DIFF
--- a/data/dl/ACCESSCONTROL-ROLEACTIONS/roleactions.json
+++ b/data/dl/ACCESSCONTROL-ROLEACTIONS/roleactions.json
@@ -31788,12 +31788,6 @@
     "tenantId": "dl"
    },
    {
-    "rolecode": "BUDGET_CREATOR",
-    "actionid": 1763,
-    "actioncode": "approve uploaded budget",
-    "tenantId": "dl"
-   },
-   {
     "rolecode": "BUDGET_APPROVER",
     "actionid": 1763,
     "actioncode": "approve uploaded budget",

--- a/data/dl/ACCESSCONTROL-ROLEACTIONS/roleactions.json
+++ b/data/dl/ACCESSCONTROL-ROLEACTIONS/roleactions.json
@@ -31708,6 +31708,96 @@
       "actionid": 2956,
       "actioncode": "",
       "tenantId": "dl"
-    }
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 2928,
+    "actioncode": "add budget",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1761,
+    "actioncode": "budget appropriation",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_APPROVER",
+    "actionid": 1761,
+    "actioncode": "budget appropriation",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1762,
+    "actioncode": "upload budget",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1755,
+    "actioncode": "create budget group",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1756,
+    "actioncode": "view budget group",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1758,
+    "actioncode": "create budget definition",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1759,
+    "actioncode": "view budget definition",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1760,
+    "actioncode": "update budget definition",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1764,
+    "actioncode": "search budget",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_APPROVER",
+    "actionid": 1764,
+    "actioncode": "search budget",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1771,
+    "actioncode": "budget uploaded report",
+    "tenantId": "dl"
+    },
+    {
+    "rolecode": "BUDGET_APPROVER",
+    "actionid": 1771,
+    "actioncode": "budget uploaded report",
+    "tenantId": "dl"
+   },
+   {
+    "rolecode": "BUDGET_CREATOR",
+    "actionid": 1763,
+    "actioncode": "approve uploaded budget",
+    "tenantId": "dl"
+   },
+   {
+    "rolecode": "BUDGET_APPROVER",
+    "actionid": 1763,
+    "actioncode": "approve uploaded budget",
+    "tenantId": "dl"
+   }
   ]
 }

--- a/data/dl/ACCESSCONTROL-ROLES/roles.json
+++ b/data/dl/ACCESSCONTROL-ROLES/roles.json
@@ -281,6 +281,16 @@
       "code": "BANK_ACCOUNT_APPROVER",
       "name": "Bank Account Inbox",
       "description": "User can Approve the Bank Account Created"
+    },
+    {
+      "code": "BUDGET_CREATOR",
+      "name": "Budget creator",
+      "description": "User can create the Budget"
+    },
+    {
+      "code": "BUDGET_APPROVER",
+      "name": "Budget approver",
+      "description": "User can approve the Budget"
     }
   ]
 }


### PR DESCRIPTION
BUDGET-CREATOR: add budget (2928), budget appropriation (1761), upload budget (1762), create/view budget group (1755,1756), create/view/update budget definition (1758,1759,1760), search budget (1764), budget uploaded report (1771)

BUDGET_APPROVER: budget appropriation (1761), search budget (1764), budget uploaded report (1771), approve uploaded budget (1763)